### PR TITLE
remove break-all and text-ellipsis classnames

### DIFF
--- a/src/components/Message.jsx
+++ b/src/components/Message.jsx
@@ -72,7 +72,7 @@ export default function Message({ message, i }) {
             {badges.slice(1, badges.length).map((badge, i) => badge("ml-1", i))}
           </div>
           <p
-            className={`self-start text-slate-50 text-xl text-start flex flex-wrap break-all text-ellipsis font-inter`}
+            className={`self-start text-slate-50 text-xl text-start flex flex-wrap font-inter`}
             dangerouslySetInnerHTML={{
               __html: message.msg,
             }}


### PR DESCRIPTION
Este PR soluciona #2.

Al remover las clases `break-all` y `text-ellipsis`, hace que el texto sea más legible cuándo se envían mensajes largos.

![Screenshot 2023-08-19 101238](https://github.com/chrisvill2312/obs-chat/assets/38303370/e74594c6-9412-4df3-ace0-862d14cbdbfb)
