### PR TITLE
Agregar soporte para Firefox

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -25,15 +25,5 @@ module.exports = {
       version: 'detect'
     }
   },
-  plugins: ['react'],
-  rules: {
-    'max-len': [
-      'warn',
-      {
-        code: 80,
-        tabWidth: 2,
-        comments: 80
-      }
-    ]
-  }
+  plugins: ['react']
 }

--- a/src/hooks/use_connect_websocket_to_twitch_irc.js
+++ b/src/hooks/use_connect_websocket_to_twitch_irc.js
@@ -12,6 +12,7 @@ export default function useConnectWebSocketToTwitchIRC() {
   const accessToken = getVariable(ACCESS_TOKEN)
   const clientId = getVariable(CLIENT_ID)
   const channel = getVariable(CHANNEL)
+
   /*
       Si no tengo el token para acceder al contenido del chat abro el OAuth de
       twitch para conseguirlo. Espero que por param de la URL me llegue el
@@ -19,17 +20,18 @@ export default function useConnectWebSocketToTwitchIRC() {
       param CLientID o tenerlo ya el LocalStorage (registrado ya como APP en
       la consola de Twitch) para ejecutar el OAuth y recibir el Token
   */
-  if (!accessToken) {
-    clientId &&
+
+  if (accessToken === undefined) {
+    const URL = `https://id.twitch.tv/oauth2/authorize?response_type=token&client_id=${clientId}&redirect_uri=${redirectUri}`
+
+    if ('navigation' in window) {
       // eslint-disable-next-line no-undef
-      navigation.navigate(
-        // navigation object exists on the supported browsers
-        // eslint-disable-next-line max-len, no-unneeded-ternary
-        `https://id.twitch.tv/oauth2/authorize?response_type=token&client_id=${clientId}&redirect_uri=${
-          redirectUri || 'http://localhost:5173/&scope=chat%3Aread'
-        }`
-      )
+      navigation.navigate(URL)
+    } else {
+      window.location.href = URL
+    }
   }
+
   /*
       Una vez tengo el Token de acceso a twitch abro un websocket para
       conectarme al IRC, autenticarme y empezar a recibir los mensajes.


### PR DESCRIPTION
Esta PR soluciona #5.

1. Ya que Firefox no soporta la [Navigation API](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API) se utiliza como fallback la [Location API](https://developer.mozilla.org/en-US/docs/Web/API/Location).

https://github.com/chrisvdev/obs-chat/assets/38303370/9cccddc7-11c0-4577-9215-08525a7d4628

2. Otro cambio menor: Eliminar reglas innecesarias de ESLint.
